### PR TITLE
refactor: Update spellchecker demo for editable HTML input

### DIFF
--- a/color-analyzer-frontend/src/app/app.component.html
+++ b/color-analyzer-frontend/src/app/app.component.html
@@ -47,9 +47,19 @@
 
   <div>
     <h2>Spellchecker Demo</h2>
-    <p>The text below should have mispelled words underlined in red (wavy).</p>
+    <p>Type in the box below. Misspelled words will be underlined in the display area.</p>
+
     <div
-      style="border: 1px solid #eee; padding: 10px; margin-top: 10px; background-color: #f9f9f9;"
+      #editableDiv
+      contenteditable="true"
+      (input)="onContentEditableInput($event)"
+      style="border: 1px solid #ccc; padding: 10px; margin-bottom: 10px; min-height: 100px; background-color: white;"
+      placeholder="Type here...">
+    </div>
+
+    <h3>Display with Spellcheck:</h3>
+    <div
+      style="border: 1px solid #eee; padding: 10px; margin-top: 10px; background-color: #f9f9f9; min-height: 100px;"
       [innerHTML]="htmlContent"
       appSpellcheckDisplay>
     </div>

--- a/color-analyzer-frontend/src/app/app.component.ts
+++ b/color-analyzer-frontend/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, ElementRef, ViewChild, AfterViewInit } from '@angular/core';
 import { ColorAnalysisService, ColorAnalysisResponse, ColorFrequencyMap } from './services/color-analysis.service';
 import { CommonModule } from '@angular/common'; // Required for *ngIf, *ngFor etc.
 import { FormsModule } from '@angular/forms'; // Required for ngModel
@@ -6,8 +6,8 @@ import { SpellcheckDisplayDirective } from './directives/spellcheck-display.dire
 
 @Component({
   selector: 'app-root',
-  standalone: true, // Assuming Angular 17+ standalone components by default from ng new
-  imports: [CommonModule, FormsModule, SpellcheckDisplayDirective], // Add FormsModule and SpellcheckDisplayDirective here
+  standalone: true,
+  imports: [CommonModule, FormsModule, SpellcheckDisplayDirective],
   templateUrl: './app.component.html',  // Corrected to conventional name
   styleUrls: ['./app.component.css']    // Corrected to conventional name
 })
@@ -24,6 +24,8 @@ export class AppComponent {
   resultMap: ColorFrequencyMap | null = null;
   resultArray: string[] | null = null;
 
+  @ViewChild('editableDiv') editableDiv!: ElementRef<HTMLDivElement>;
+
   // Content for spellchecking directive
   htmlContent: string = `
     <p>This is a paragarph with some deliberatly mispelled words.</p>
@@ -35,6 +37,17 @@ export class AppComponent {
   `;
 
   constructor(private colorAnalysisService: ColorAnalysisService) {}
+
+  ngAfterViewInit(): void {
+    if (this.editableDiv) {
+      this.editableDiv.nativeElement.innerHTML = this.htmlContent;
+    }
+  }
+
+  onContentEditableInput(event: Event): void {
+    const target = event.target as HTMLDivElement;
+    this.htmlContent = target.innerHTML;
+  }
 
   analyzeUrl(): void {
     if (!this.urlToAnalyze) {

--- a/color-analyzer-frontend/src/app/directives/spellcheck-display.directive.ts
+++ b/color-analyzer-frontend/src/app/directives/spellcheck-display.directive.ts
@@ -1,6 +1,11 @@
 import { Directive, ElementRef, Input, OnChanges, Renderer2, SimpleChanges, OnInit } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import * as NSpell from 'nspell';
+// Import as a namespace
+import * as NSpellNamespace from 'nspell';
+
+// Define the type for the NSpell instance
+// It's likely NSpellNamespace.NSpell if @types/nspell defines NSpell within the module's export scope.
+type NSpellInstance = NSpellNamespace.NSpell;
 
 @Directive({
   selector: '[appSpellcheckDisplay]',
@@ -8,8 +13,7 @@ import * as NSpell from 'nspell';
 })
 export class SpellcheckDisplayDirective implements OnChanges, OnInit {
   @Input() htmlContent: string = '';
-
-  private spell: NSpell.NSpell | null = null;
+  private spell: NSpellInstance | null = null;
   private dictionaryLoaded: boolean = false;
 
   constructor(
@@ -32,13 +36,13 @@ export class SpellcheckDisplayDirective implements OnChanges, OnInit {
     try {
       const affPromise = this.http.get('assets/en_US.aff', { responseType: 'text' }).toPromise();
       const dicPromise = this.http.get('assets/en_US.dic', { responseType: 'text' }).toPromise();
-
       const [affData, dicData] = await Promise.all([affPromise, dicPromise]);
 
       if (affData && dicData) {
-        this.spell = NSpell(affData, dicData);
+        // Try to access the nspell function, assuming it might be on .default or the namespace itself
+        const nspellFunction = (NSpellNamespace as any).default || NSpellNamespace;
+        this.spell = nspellFunction(affData, dicData);
         this.dictionaryLoaded = true;
-        // If htmlContent was already set, update it now
         if (this.htmlContent) {
           this.updateContent();
         }
@@ -54,7 +58,6 @@ export class SpellcheckDisplayDirective implements OnChanges, OnInit {
 
   private updateContent(): void {
     if (!this.spell || !this.htmlContent) {
-      // If spell is not loaded or no content, just set original HTML
       this.renderer.setProperty(this.el.nativeElement, 'innerHTML', this.htmlContent || '');
       return;
     }
@@ -68,7 +71,7 @@ export class SpellcheckDisplayDirective implements OnChanges, OnInit {
     this.renderer.setProperty(this.el.nativeElement, 'innerHTML', tempDiv.innerHTML);
   }
 
-  private walkAndSpellcheck(node: Node, spellChecker: NSpell.NSpell): void {
+  private walkAndSpellcheck(node: Node, spellChecker: NSpellInstance): void {
     if (node.nodeType === Node.TEXT_NODE) {
       const textNode = node as Text;
       let newHtml = '';
@@ -90,13 +93,9 @@ export class SpellcheckDisplayDirective implements OnChanges, OnInit {
         const span = this.renderer.createElement('span');
         this.renderer.setProperty(span, 'innerHTML', newHtml);
         // Replace the text node with the new span containing potentially highlighted words
-        // This needs to be done carefully to avoid issues if the parent is not an element or if the node is already removed.
         try {
             textNode.parentNode.replaceChild(span, textNode);
         } catch (e) {
-            // Fallback or error logging if replaceChild fails
-            // This can happen if the text node was part of a larger replacement
-            // For simplicity, we'll log and it might mean some deeply nested text isn't spellchecked
             console.warn("Could not replace text node during spellcheck:", e);
         }
       }

--- a/color-analyzer-frontend/tsconfig.app.json
+++ b/color-analyzer-frontend/tsconfig.app.json
@@ -4,7 +4,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "./out-tsc/app",
-    "types": []
+    "types": [],
+    "allowSyntheticDefaultImports": true
   },
   "include": [
     "src/**/*.ts"

--- a/color-analyzer-frontend/tsconfig.json
+++ b/color-analyzer-frontend/tsconfig.json
@@ -13,7 +13,8 @@
     "experimentalDecorators": true,
     "importHelpers": true,
     "target": "ES2022",
-    "module": "preserve"
+    "module": "preserve",
+    "allowSyntheticDefaultImports": true
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,


### PR DESCRIPTION
Modifies the AppComponent to use two divs for the spellchecker demonstration:
- One div is contenteditable, allowing the user to input and edit HTML directly.
- The second div displays the content from the editable div, with the appSpellcheckDisplay directive applying spellchecking and highlighting.

This change addresses the issue where the directive's rewriting of innerHTML prevented direct editing on the element it was applied to. AppComponent now uses @ViewChild and ngAfterViewInit to manage the initial content of the editable div and updates its htmlContent property based on user input, which then feeds the spellcheck display div.